### PR TITLE
Clean up readme and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Data. Together. Let's read about it
 🎯 Participation link (recorded): [https://edgi-video-call-landing-page.herokuapp.com/https://zoom.us/j/847315566](https://edgi-video-call-landing-page.herokuapp.com/https://zoom.us/j/847315566)  
 ▶️ [**Data Together Call Playlist**](https://www.youtube.com/playlist?list=PLtsP3g9LafVul1gCctMYGm9sz5FUWr5bu)
 
-We want to understand better just what it is that we're doing! The goal of this "syllabus" is to identify some key themes that drive Data Together as a project & as a politics, and to find some readings that help us understand those themes better.
+We want to understand better just what it is that we're doing! The goal of this "syllabus" is to identify some themes that drive Data Together as a project & as a politics, and to find some readings that help us understand those themes better.
 
-Once a month on **Tuesday afternoon** we'll host a 1.5 hour discussion of one of [six themes](#themes) over summer 2018. Everyone should try hard to read the *core* reading (~30 pages), and once or twice sign up to facilitate discussion.
+Once a month on **Tuesday afternoon** we'll host a 1.5 hour discussion of one of [six themes](#themes) over summer 2018. Everyone should try hard to read the *core* reading (~30 pages), and once or twice sign up to [facilitate discussion](#facilitation).
 
-From this initial iteration, our hope is that the following outcomes occur: first, we learn together! second, through documenting the discussion we understand Data Together principles and see opportunities to feed into ongoing other initiatives and projects
+From this initial iteration, our hope is that: first, we learn together!; second, through documenting discussion we can articulate Data Together principles.
 
 ## Themes  
 
@@ -68,7 +68,7 @@ Sometimes, instead of ownership, we talk about a "commons". How ought the common
 ([WorldCat](https://www.worldcat.org/title/stop-thief-the-commons-enclosures-and-resistance/oclc/1002229329))
 ([Academia.edu](https://www.academia.edu/11651199/Peter_Linebaugh-_Stop_Thief_The_Commons_Enclosures_and_Resistance-PM_Press_2014_))
 ([Amazon.com](https://www.amazon.com/Stop-Thief-Commons-Enclosures-Resistance/dp/1604867477/))
-- [Primavera De Filippi & Felix Tréguer (2015) Expanding the Internet commons: The subversive potential of wireless community networks.](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2725358)
+- Primavera De Filippi & Felix Tréguer (2015) [Expanding the Internet commons: The subversive potential of wireless community networks.](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2725358)
   - _Alternate_: [Primavera De Filippi & Felix Tréguer (2014) Expanding the Internet commons: The subversive potential of wireless community networks _Journal of Peer Production_](http://peerproduction.net/issues/issue-6-disruption-and-the-law/peer-reviewed-articles/expanding-the-internet-commons-the-subversive-potential-of-wireless-community-networks/) ([**PDF**](http://peerproduction.net/wp-content/uploads/2015/01/De-Filippi-Tr%C3%A9guer-Expanding-the-Internet-Commons-with-Community-Networks.pdf))
 
 
@@ -82,7 +82,7 @@ Sometimes, instead of ownership, we talk about a "commons". How ought the common
 
 ### Privacy
 
-Lately we've been hearing some interesting critiques of "privacy as a concept and moral imperative". Let's see if we think they hame sense.
+Lately we've been hearing some interesting critiques of "privacy as a concept and moral imperative". Let's see if we think they make sense.
 
 **Readings**:
 

--- a/notes/1-decentralized-web-2018-06-26.md
+++ b/notes/1-decentralized-web-2018-06-26.md
@@ -8,9 +8,11 @@ Just getting us all on the same page about this very, er, central question, and 
 
 **Readings**
 
-- Brewster Kahle: [Locking the Web Open, a Call for a Distributed Web](http://brewster.kahle.org/2015/04/22/locking-the-web-open-a-call-for-a-distributed-web/) or [Locking the Web Open: A Call for a Decentralized Web (longer form)](http://brewster.kahle.org/2015/08/11/locking-the-web-open-a-call-for-a-distributed-web-2/)
-- André Staltz ["The Web Began Dying in 2014, Here's How"](https://staltz.com/the-web-began-dying-in-2014-heres-how.html)
-- [Baran, P. (1964). _On Distributed Communications_ (No. RM-4230-PR). Santa Monica, CA: Rand Corporation.](https://www.rand.org/pubs/research_memoranda/RM3420.html)
+- Brewster Kahle (2015) ["Locking the Web Open, a Call for a Distributed Web"](http://brewster.kahle.org/2015/04/22/locking-the-web-open-a-call-for-a-distributed-web/)
+  - _Alternate_: Brewster Kahle (2015) ["Locking the Web Open: A Call for a Decentralized Web" (longer form)](http://brewster.kahle.org/2015/08/11/locking-the-web-open-a-call-for-a-distributed-web-2/)
+- André Staltz (2017) ["The Web Began Dying in 2014, Here's How"](https://staltz.com/the-web-began-dying-in-2014-heres-how.html)
+- Paul Baran (1964) [On Distributed Communications (No. RM-4230-PR). Santa Monica, CA: Rand Corporation. doi:10.7249/RM3420 ](https://www.rand.org/pubs/research_memoranda/RM3420.html)
+  - _Alternate_: Paul Baran (1964) [On Distributed Communications Networks. _IEEE Transactions on Communications Systems_, 12(1). doi:10.1109/TCOM.1964.1088883](https://ieeexplore.ieee.org/abstract/document/1088883/)
 
 ### Themes
 

--- a/notes/1-decentralized-web-2018-06-26.md
+++ b/notes/1-decentralized-web-2018-06-26.md
@@ -8,21 +8,21 @@ Just getting us all on the same page about this very, er, central question, and 
 
 **Readings**
 
-- Brewster Kahle: [Locking the Web Open, a Call for a Distributed Web](http://brewster.kahle.org/2015/04/22/locking-the-web-open-a-call-for-a-distributed-web/) or [Locking the Web Open: A Call for a Decentralized Web (longer form)](http://brewster.kahle.org/2015/08/11/locking-the-web-open-a-call-for-a-distributed-web-2/)
-- André Staltz ["The Web Began Dying in 2014, Here's How"](https://staltz.com/the-web-began-dying-in-2014-heres-how.html)
-- [Baran, P. (1964). _On Distributed Communications_ (No. RM-4230-PR). Santa Monica, CA: Rand Corporation.](https://www.rand.org/pubs/research_memoranda/RM3420.html)
+- Brewster Kahle: Locking the Web Open, a Call for a Distributed Web(http://brewster.kahle.org/2015/04/22/locking-the-web-open-a-call-for-a-distributed-web/) or Locking the Web Open: A Call for a Decentralized Web (longer form)(http://brewster.kahle.org/2015/08/11/locking-the-web-open-a-call-for-a-distributed-web-2/)
+- André Staltz "The Web Began Dying in 2014, Here's How"(https://staltz.com/the-web-began-dying-in-2014-heres-how.html)
+- Baran, P. (1964). _On Distributed Communications_ (No. RM-4230-PR). Santa Monica, CA: Rand Corporation.(https://www.rand.org/pubs/research_memoranda/RM3420.html)
 
 ### Themes
 
-- What's the relationship between the Brewster Kahle vision of 2015 and where we are today? 
+- What's the relationship between the Brewster Kahle vision of 2015 and where we are today?
 - To what extent can the "Trinet" be destabilized? That is, what forces would be required to craft a different future for the Net?
 - What are the motivations in each of these different moments of distriuted enthusiasm?
-- how are they using "web" and "internet"? 
+- how are they using "web" and "internet"?
 - can we talk about decentralized vs. distributed?
 - Lessig's "code is law". how do we think about social values & technical systems, and the relationship to distributed systems?
 - Code is culture as well, what kind of cultural impact will a distributed system have?
 - example: is bitcoin or etherium "distributed"? not if you're offline.  So maybe "distributed" has different levels of meaning/nuances
-- can we talk about patchwork/ssb? Designing for non-1%ers; and how expectations shift as the platform grows. 
+- can we talk about patchwork/ssb? Designing for non-1%ers; and how expectations shift as the platform grows.
 
 ### Notes
 
@@ -35,7 +35,7 @@ Just getting us all on the same page about this very, er, central question, and 
     - Staltz: Access (Equity)
 - Subject position (and value systems) needs to be accounted for when arguing for a view
 - Values need to be based on context of use (e.g., example of Mobile Users, Facebook bottom line, Dapps and IPFS)
-- Infrastructure, behaviour, flow entangled in such a way you could decentralize and it wouldn't effect many types of change. 
+- Infrastructure, behaviour, flow entangled in such a way you could decentralize and it wouldn't effect many types of change.
 - Seeing/operating at scales (and "levels of distribution"):
     - large corporations cannot control at the small scale (but increasingly through software are to)
 - hidden pockets of communities burrowing away from the panopticon
@@ -47,7 +47,7 @@ Just getting us all on the same page about this very, er, central question, and 
 - Decentralization has a history prior to communications networks. (e.g. which one is Ostrom drawing on?)
 - Decentralization and disintermediation
 - How to hold space with contradictory values
-    - Pluralist 
+    - Pluralist
     - Change as a constant
     - "Build systems for these condradictions"
 - Two sets of types of effort: building techincal systems, building society, building society to build that system
@@ -74,85 +74,85 @@ Just getting us all on the same page about this very, er, central question, and 
 
 ### Chat Log
 
-Matt Price [03:33 PM]: https://hackmd.io/oEcuKALCTi-PbawLmT_Ixw?edit who does mtt Z keep smiling about that?  
-Matt Price [03:47 PM]: in case there's anyone who doesn't have the notes link yet: https://hackmd.io/oEcuKALCTi-PbawLmT_Ixw?edit  
-jccahill [03:49 PM]: patchwork as case study?  
-b5 [03:52 PM]: +100000  
-dcwalk [03:55 PM]: John Perry Barlow  
-Matt Price [03:55 PM]: yes exactly!  
-jccahill [03:56 PM]: constant between-groups and within-groups abrogation of norms is a major reason why i research memes  
-Matt Price [03:56 PM]: nice.  
-jccahill [03:59 PM]: does zoom actually have a "raise hand" function, like jitsi meet and others? don't see it  
-b5 [03:59 PM]: yep! it’s in the participants tab  
-Matt Price [04:01 PM]: what I said was a little simplistic.  I have expressed this kind of critique in thepast.  But I still sort of believed i nthe emancipatory possibilities of hte web. But I'm not sure I still do.  
-dcwalk [04:02 PM]: Yeah Matt, something about emancipatory potential is what grabs b5 too :]: Matt Price [04:04 PM]: my connection is a little unstable.  so I may disappear.  
-dcwalk [04:04 PM]: I can hold stack if you drop off Matt P.  
+03:33 PM  Matt Price: https://hackmd.io/oEcuKALCTi-PbawLmT_Ixw?edit who does mtt Z keep smiling about that?  
+03:47 PM  Matt Price: in case there's anyone who doesn't have the notes link yet: https://hackmd.io/oEcuKALCTi-PbawLmT_Ixw?edit  
+03:49 PM  jccahill: patchwork as case study?  
+03:52 PM  b5: +100000  
+03:55 PM dcwalk: John Perry Barlow  
+03:55 PM  Matt Price: yes exactly!  
+03:56 PM jccahill: constant between-groups and within-groups abrogation of norms is a major reason why i research memes  
+03:56 PM Matt Price: nice.  
+03:59 PM jccahill: does zoom actually have a "raise hand" function, like jitsi meet and others? don't see it  
+03:59 PM b5: yep! it’s in the participants tab  
+04:01 PM Matt Price: what I said was a little simplistic.  I have expressed this kind of critique in thepast.  But I still sort of believed i nthe emancipatory possibilities of hte web. But I'm not sure I still do.  
+04:02 PM dcwalk: Yeah Matt, something about emancipatory potential is what grabs b5 too:: Matt Price 04:04 PM: my connection is a little unstable.  so I may disappear.  
+04:04 PM dcwalk: I can hold stack if you drop off Matt P.  
 jccahill: when you use the word “patch” are you drawing on something/someone? I think like ecosystems theory and patch dynamics  
-Matt Price [04:09 PM]: rob next  
-b5 [04:09 PM]: then b5?  
-Matt Price [04:09 PM]: I want to be sure to cob5 back to this "what's the point" question.  
-dcwalk [04:09 PM]: +1 Matt P.  
-Matt Price [04:09 PM]: rob, then b5  
-dcwalk [04:10 PM]: This feels to b5 like both a co-option and move of like… entrenchment  
-dcwalk [04:10 PM]: Yeah! The it is a joint OCAD thing with the folks at New Museum  
-Matt Price [04:14 PM]: flagging the question of the "corporate environment" and the relationship between technology, democracy, and capital.  
-jccahill [04:14 PM]: re: centralization of the bottom of the networking model, now archivists have to start trying to account for eu-mandated internetwide snooping  
-Matt Price [04:15 PM]: comes back to the "levels of distribution" point matt z at the very beginning.  
-dcwalk [04:16 PM]: yeah, there is something really helpful about thinking across scales!  
-Matt Price [04:17 PM]: jeremy next. @b5 can you explicitly say how freedom of association is enhanced by distributed networks?   
+04:09 PM Matt Price: rob next  
+04:09 PM b5: then b5?  
+04:09 PM Matt Price: I want to be sure to cob5 back to this "what's the point" question.  
+04:09 PM dcwalk: +1 Matt P.  
+04:09 PM Matt Price: rob, then b5  
+04:10 PM dcwalk: This feels to b5 like both a co-option and move of like… entrenchment  
+04:10 PM dcwalk: Yeah! The it is a joint OCAD thing with the folks at New Museum  
+04:14 PM Matt Price: flagging the question of the "corporate environment" and the relationship between technology, democracy, and capital.  
+04:14 PM jccahill: re: centralization of the bottom of the networking model, now archivists have to start trying to account for eu-mandated internetwide snooping  
+04:15 PM Matt Price: comes back to the "levels of distribution" point matt z at the very beginning.  
+04:16 PM dcwalk: yeah, there is something really helpful about thinking across scales!  
+04:17 PM Matt Price: jeremy next. @b5 can you explicitly say how freedom of association is enhanced by distributed networks?   
 hi mhz!  
-dcwalk [04:19 PM]: Hi mhz!  
-Michelle Hertzfeld [04:19 PM]: :waves:  
-Matt Price [04:21 PM]: ... nazi discussion...  
-dcwalk [04:23 PM]: I think I can’t use the put up my hand feature, but can I jump on stack  
+04:19 PM dcwalk: Hi mhz!  
+04:19 PM Michelle Hertzfeld::waves:  
+04:21 PM Matt Price: ... nazi discussion...  
+04:23 PM dcwalk: I think I can’t use the put up my hand feature, but can I jump on stack  
 Hahahah tomes has a homeserver  
-dcwalk [04:24 PM]: love it — think we mentioned something about federation in a future session  
-b5 [04:25 PM]: remember microsoft  
-jccahill [04:25 PM]: >implying it still isn't. does "locking the web open" without changing the 90-9-1 distribution actually lock it open  
-Matt Price [04:27 PM]: ^^. putting myself on stack.  
-b5 [04:30 PM]: to answer above, “freedom of association” in the sense of being able to explicitly choose who I connect with in the p2p sense. By being able to choose who I connect to and get content from.  
-dcwalk [04:32 PM]: Yeah, so stuck on this. Donella Meadows has this short article “Leverage Points: Ways to intervene in a System"  
+04:24 PM dcwalk: love it — think we mentioned something about federation in a future session  
+04:25 PM b5: remember microsoft  
+04:25 PM jccahill: >implying it still isn't. does "locking the web open" without changing the 90-9-1 distribution actually lock it open  
+04:27 PM Matt Price: ^^. putting myself on stack.  
+04:30 PM b5: to answer above, “freedom of association” in the sense of being able to explicitly choose who I connect with in the p2p sense. By being able to choose who I connect to and get content from.  
+04:32 PM dcwalk: Yeah, so stuck on this. Donella Meadows has this short article “Leverage Points: Ways to intervene in a System"  
 this is my systems thinking quals showing thru  
-mash [04:33 PM]: perhaps individual countries don’t have as much power but what about things like the recent EU copyright directive  
-dcwalk [04:34 PM]: No I was just gonna say “can we have a sentence of context”  
-Michelle Hertzfeld [04:34 PM]: That would be lovely :)   
-Matt Price [04:35 PM]: 30 minutes left.  
-b5 [04:35 PM]: so agreed, nation stats & the web are…. a tangled story.  
-Matt Price [04:35 PM]: what do we want to make sure we talk about?  
-dcwalk [04:37 PM]: Not necessarily, I’m just saying that I take it up in this context  
-Matt Price [04:37 PM]: sorry, zoom is using like 300% of cpu in like 87 threads.  
-b5 [04:37 PM]: I think rob’s next  
-Michelle Hertzfeld [04:38 PM]: The "what are we trying to do here, what are the outcomes we're trying to achieve" -- yeah, that totally makes sense  
-b5 [04:39 PM]: jeremy next  
-dcwalk [04:39 PM]: Jeremy on stack for next?  
-jccahill [04:39 PM]: thx  
-Michelle Hertzfeld [04:40 PM]: Talking past each other without clear articulation of outcomes = almost every open source project ever :-/  
-b5 [04:42 PM]: feels like the intersection of “systems design” in the technical sense and a “value system”  
+04:33 PM mash: perhaps individual countries don’t have as much power but what about things like the recent EU copyright directive  
+04:34 PM dcwalk: No I was just gonna say “can we have a sentence of context”  
+04:34 PM Michelle Hertzfeld: That would be lovely:)   
+04:35 PM Matt Price: 30 minutes left.  
+04:35 PM b5: so agreed, nation stats & the web are…. a tangled story.  
+04:35 PM Matt Price: what do we want to make sure we talk about?  
+04:37 PM dcwalk: Not necessarily, I’m just saying that I take it up in this context  
+04:37 PM Matt Price: sorry, zoom is using like 300% of cpu in like 87 threads.  
+04:37 PM b5: I think rob’s next  
+Michelle Hertzfeld 04:38 PM: The "what are we trying to do here, what are the outcomes we're trying to achieve" -- yeah, that totally makes sense  
+04:39 PM b5: jeremy next  
+04:39 PM dcwalk: Jeremy on stack for next?  
+04:39 PM jccahill: thx  
+04:40 PM Michelle Hertzfeld: Talking past each other without clear articulation of outcomes = almost every open source project ever:-/  
+04:42 PM b5: feels like the intersection of “systems design” in the technical sense and a “value system”  
 matt p next  
-dcwalk [04:46 PM]: I feel like we have a floating moderation that I’m really digging rn  
-jccahill [04:46 PM]: >how do you build a society that you'd want to live in   >that hasn't been done yet  
-jccahill [04:46 PM]: matt doesn't live in a society  
-dcwalk [04:46 PM]: “tech lash” can I jump up next  
-Matt Zumwalt [04:48 PM]: then me!  
-Matt Price [04:49 PM]: ... matt p, pretending to be the moderator again. 9 minutes.  
-dcwalk [(null)]: I’ll dig up the Eve Tuck letter (it is very readable!]:   
-Matt Price [(null)]: I think there of the haitian revolution.  
-dcwalk [04:53 PM]: perfect hand off to talking about memes?  
-Matt Price [04:53 PM]: its relationship to the fr revn, which was different form its relationship to the napoleonic empire!  
-mash [04:54 PM]: this kind of experimentation is pretty much what Facebook is doing, incrementally  
-b5 [04:54 PM]: the “problem group"  
-dcwalk [04:54 PM]: Yo, I just re-read the Dispossessed and I’m like all full of thinking about Odonism  
-jccahill [04:54 PM]: fwiw "meb5 studies" is a totally syncretic new attempt at a field and we have been thinking about how a reading group would work  
-dcwalk [04:55 PM]: jccahill: can you share links in that notes?  
+04:46 PM  dcwalk: I feel like we have a floating moderation that I’m really digging rn  
+04:46 PM jccahill: >how do you build a society that you'd want to live in   >that hasn't been done yet  
+04:46 PM jccahill: matt doesn't live in a society  
+04:46 PM dcwalk: “tech lash” can I jump up next  
+04:48 PM Matt Zumwalt: then me!  
+04:49 PM Matt Price: ... matt p, pretending to be the moderator again. 9 minutes.  
+dcwalk (null): I’ll dig up the Eve Tuck letter (it is very readable!:   
+Matt Price (null): I think there of the haitian revolution.  
+dcwalk 04:53 PM: perfect hand off to talking about memes?  
+04:53 PM  Matt Price: its relationship to the fr revn, which was different form its relationship to the napoleonic empire!  
+04:54 PM mash: this kind of experimentation is pretty much what Facebook is doing, incrementally  
+04:54 PM b5: the “problem group"  
+04:54 PM dcwalk: Yo, I just re-read the Dispossessed and I’m like all full of thinking about Odonism  
+04:54 PM jccahill: fwiw "meb5 studies" is a totally syncretic new attempt at a field and we have been thinking about how a reading group would work  
+04:55 PM dcwalk: jccahill: can you share links in that notes?  
 Super interested! I love Geert Lovink’s principles of meb5 design  
-Matt Zumwalt [04:56 PM]: https://github.com/datatogether/reading-data-together  
-jccahill [04:56 PM]: dawn: we're building a research library. there's a grouplib on zotero and an omeka site going up. will be able to link soonish  
-dcwalk [04:57 PM]: Please!  
-b5 [04:58 PM]: yes so much! I’d love to see sob5 of Jermey’s suggestions land in there :]:   
-Matt Price [04:59 PM]: feels more practical  
-Matt Zumwalt [05:00 PM]: coordination is happening in this GitHub repo: https://github.com/datatogether/reading-data-together  
-dcwalk [05:01 PM]: Thank you Matt P. for moderating!!!!!!!!!  
-Michelle Hertzfeld [05:01 PM]: Thx for filling b5 in, the late arrival! Thx, all!!  
-jccahill [05:01 PM]: thanks all  
-mash [05:01 PM]: thank you, this was very interesting  
-jccahill [05:01 PM]: apologies to all slacks-wearers
+04:56 PM Matt Zumwalt: https://github.com/datatogether/reading-data-together  
+04:56 PM jccahill: dawn: we're building a research library. there's a grouplib on zotero and an omeka site going up. will be able to link soonish  
+04:57 PM dcwalk: Please!  
+04:58 PM b5: yes so much! I’d love to see sob5 of Jermey’s suggestions land in there::   
+04:59 PM Matt Price: feels more practical  
+05:00 PM Matt Zumwalt: coordination is happening in this GitHub repo: https://github.com/datatogether/reading-data-together  
+05:01 PM dcwalk: Thank you Matt P. for moderating!!!!!!!!!  
+Michelle Hertzfeld: Thx for filling b5 in, the late arrival! Thx, all!!  
+05:01 PM jccahill: thanks all  
+05:01 PM mash: thank you, this was very interesting  
+05:01 PM jccahill: apologies to all slacks-wearers

--- a/notes/1-decentralized-web-2018-06-26.md
+++ b/notes/1-decentralized-web-2018-06-26.md
@@ -8,9 +8,9 @@ Just getting us all on the same page about this very, er, central question, and 
 
 **Readings**
 
-- Brewster Kahle: Locking the Web Open, a Call for a Distributed Web(http://brewster.kahle.org/2015/04/22/locking-the-web-open-a-call-for-a-distributed-web/) or Locking the Web Open: A Call for a Decentralized Web (longer form)(http://brewster.kahle.org/2015/08/11/locking-the-web-open-a-call-for-a-distributed-web-2/)
-- André Staltz "The Web Began Dying in 2014, Here's How"(https://staltz.com/the-web-began-dying-in-2014-heres-how.html)
-- Baran, P. (1964). _On Distributed Communications_ (No. RM-4230-PR). Santa Monica, CA: Rand Corporation.(https://www.rand.org/pubs/research_memoranda/RM3420.html)
+- Brewster Kahle: [Locking the Web Open, a Call for a Distributed Web](http://brewster.kahle.org/2015/04/22/locking-the-web-open-a-call-for-a-distributed-web/) or [Locking the Web Open: A Call for a Decentralized Web (longer form)](http://brewster.kahle.org/2015/08/11/locking-the-web-open-a-call-for-a-distributed-web-2/)
+- André Staltz ["The Web Began Dying in 2014, Here's How"](https://staltz.com/the-web-began-dying-in-2014-heres-how.html)
+- [Baran, P. (1964). _On Distributed Communications_ (No. RM-4230-PR). Santa Monica, CA: Rand Corporation.](https://www.rand.org/pubs/research_memoranda/RM3420.html)
 
 ### Themes
 

--- a/notes/2-ownership-2018-07-24.md
+++ b/notes/2-ownership-2018-07-24.md
@@ -116,136 +116,136 @@ where owners wanted to e
 
 ###  Chat Log
 
-00:13:20	dcwalk: Just doing intros matt!
-00:13:37	dcwalk: Asked folks to also add thoughts to the pad
-00:13:54	Matt Price: I can't hear yet.  sorry, hopefully fix it soon.
-00:14:15	dcwalk: okay! do your intro last
-00:14:53	Matt Price: just got it
-00:15:29	jcahill: problems
-00:15:31	jcahill: sorry
-00:15:35	Brendan O'Brien: no worries!
-00:15:59	Matt Price: mash not matt...
-00:16:09	dcwalk: Song-Young you next?
-00:16:13	dcwalk: Then me than matt!
-00:16:14	Brendan O'Brien: welcome mash!
-00:16:21	Matt Price: +1
-00:16:29	dcwalk: Awesome!
-00:16:49	Brendan O'Brien: lovely! welcome Seong-Young!
-00:17:16	dcwalk: JCA if you are able to intro please feel free after matt
-00:17:26	dcwalk: Otherwise I’m handing off facilitator duties
-00:17:49	dcwalk: My fault!
-00:18:32	dcwalk: https://hackmd.io/oEcuKALCTi-PbawLmT_Ixw?view
-00:20:10	mash: me
-00:23:04	mash: https://onlinelibrary.wiley.com/doi/full/10.1002/bult.2006.1720330108 one of the references from the wiki article that I thought was interesting, relates to the goodreads article as well
-00:25:33	jccahill: i switched over machines, and apparently accounts (still jeremy here)
-00:25:54	Rob Brackett: counter-anti, not enough negatives :P
-00:26:04	Brendan O'Brien: counter-anti-dis
-00:26:12	Brendan O'Brien: counter-anti-that
-00:26:12	jccahill: anti-disestablishment-anti-counter-disintermediationism
-00:27:42	Matt Price: plugged i nthis time.
-00:27:56	dcwalk: I poorly stepped in!
-00:28:02	dcwalk: We’re on the wiki article
-00:28:15	dcwalk: (into the rest :)))
-00:30:30	dcwalk: Matt P. you on stack?
-00:30:32	Brendan O'Brien: back when we called it ARPANET?
-00:30:45	Rob Brackett: virtually raising my hand
-00:31:06	Matt Price: yes I'm on stack too.
-00:32:02	Rob Brackett: COLLEGE STUDENT ME NEVER KNEW I COULD HAVE DONE THAT ON FACEBOOK
-00:32:21	Matt Price: me neever
-00:32:45	dcwalk: Stack:
-00:32:46	Brendan O'Brien: and our URL is more popular
-00:32:53	dcwalk: matt p, rob, then me!
-00:33:14	Brendan O'Brien: so sorry team I have to jet. jachill & mash that was lovely!
-00:33:24	dcwalk: by b5!
-00:33:38	mash: byebye!
-00:33:40	dcwalk: :( today is typo day
-00:34:46	jccahill: i don't know enough to speak to the details, but patchwork has been going through some tribulations in its community norms wrt early adopters vs. others
-00:37:35	mash: stack me
-00:39:08	Matt Price: interesting @jccahill
-00:39:12	Matt Price: gotcha mash
-00:41:03	Matt Price: age of mechanical reproduction (benjamin)
-00:41:43	Michelle Brous: Hey team, really sorry but some time sensitive things have landed on my desk over the past 20 mins or so. Going to log off - enjoy the convo!
-00:41:43	Matt Price: the word "capitalism" always so difficult for me b/c it is so broad.
-00:41:57	Seong-Young Her: me next please
-00:42:10	Matt Price: gotta bring in the dog, back to you for 3 mins dcwalk
-00:43:50	dcwalk: phew! you said it so smooth-like :))
-00:45:32	Matt Price: @mash, so I htink you are talking more broadly about the problem of collective action, is that right?  and how people get the notion that they have strong common interests with their peers.
-00:46:04	dcwalk: I like that enclosure // sanctuary pairing. yeah
-00:46:25	jccahill: difference between an enclosure and a sanctuary: whether you want more to be next to the people inside or outside?
-00:46:48	Matt Price: mechanical turks
-00:48:50	jccahill: i'd also like to try to address: the flattening of "audience" and content creators on media platforms, in terms of conflating their interests -- which aren't fully aligned. masha and i went through some platformcoop-endorsed/listed alternatives to sites like spotify
-00:49:00	jccahill: ex. resonate
-00:49:09	Matt Price: that last point from rob strongly reminded me of michelle's trip to winniped this weekend.
-00:49:30	Matt Price: she visited the land her metis ancestors had before the metis rebellion in late c. 19.
-00:50:30	jccahill: dcwalk: that relates to a thing seong and i read recently, about the units of analysis for measuring connectivity in different fields
-00:50:56	jccahill: is the "more fundamental" unit of social network analysis an actor, or an interaction?
-00:51:34	mash: put jeremy on the stack pls
-00:53:10	jccahill: interesting (to me) sociolinguistic note: programmers are perfectly content to use "first-class citizen" in contrast to other things when discussing technical specs, but you don't see this elsewhere ex: computers that actually handle distribution of IPsbehind NAT, etc
-00:53:16	dcwalk: I AGREE
-00:53:22	dcwalk: the quote: “The basic strategy of antidisintermediation was formulated by economists like Carl Shapiro and Hal R. Varian. Their influential book Information Rules encourages platform owners to pursue “lock-in.” As they summarize on their website, “Since information technology products work in systems, switching any single product can cost users dearly. The lock-in that results from such switching costs confers a huge competitive advantage to firms that manage their installed base of customers effectively.”
-00:53:37	dcwalk: “Decentralized systems need to be designed to be counteranti-disintermediationist. Central to the counterantidisintermediationist design is the end- to-end principle; platforms must not depend on servers and admins, even when cooperatively run, but must, to the greatest degree possible, run on the computers of the platforms users.”
-00:56:36	dcwalk: That seems like a powerful site for action…? people getting called to action
-00:59:22	mash: reminds me of the history of fandoms (copyright war waged by authors on fan fiction writers/artists)
-01:00:48	Kevin Nguyen: Can you link to patchwork?
-01:01:13	dcwalk: https://github.com/ssbc/patchwork y’all should add me on it ;)
-01:01:43	Kevin Nguyen: thanks!
-01:05:45	dcwalk: can I go next? (it’ll be short!)
-01:06:44	Matt Price: after dcwalk I see Rob
-01:07:39	Matt Price: I would like to make sure we pick up Rob's very first point -- about the divergent interests of owners and users of platforms -- although I think I kind of stopped him from discussing it in more detail earlier :-/
-01:08:04	Matt Price: oh yeah that too.
-01:08:51	dcwalk: yeah! +1 Rob’s point
-01:08:59	dcwalk: dooo it
-01:09:09	dcwalk: Anna Tsing
-01:10:25	Matt Price: https://press.princeton.edu/titles/10581.html
-01:13:02	dcwalk: Other language: nested hierarchy, poly centric (Ostrom) and con federalism (Bookchin!!!!!!!!)
-01:13:18	Kevin Nguyen: Have to jet early, so good hearing about everything. Thanks all!
-01:14:47	jccahill: do you want to talk about specific platform coop examples?
-01:15:23	jccahill: there's an index on the platform.coop site, i'll fetch it
-01:16:20	Matt Price: also the other site, besides life insurance, of the emergence of actuarial thinking mid-century.
-01:16:23	Matt Price: 19th
-01:16:37	jccahill: platform.coop/directory
-01:16:59	Matt Price: never heard it said out loud before...
-01:18:15	Matt Price: I feel so ignorant here.
-01:19:05	Seong-Young Her: the four approaches mentioned by Trebor Scholz:
-1. Standards and guidelines for platforms to be enforced by policy (e.g. Domestic Workers Alliance's "Good Work Code")
-2. Economic regulations and union rights (e.g. Seattle tax on Uber)
-3. Developing non-commercial alternatives (e.g. Wikipedia)
-4. Platform cooperativism
-01:19:28	dcwalk: Thanks Seong-Young!
-01:20:15	Seong-Young Her: the seven Rochdale Principles mentioned by Nathan Schneider (pulled from Wikipedia):
-1. The first of the Rochdale Principles states that co-operative societies must have an open and voluntary membership.
-2. The second of the Rochdale Principles states that co-operative societies must have democratic member control.
-3. Member economic participation is one of the defining features of co-operative societies, and constitutes the third Rochdale Principle in the ICA's Statement on the Co-operative Identity.
-4. The fourth of the Rochdale Principles states that co-operative societies must be autonomous and independent.
-5. The fifth of the Rochdale Principles states that co-operative societies must provide education and training to their members and the public.
-6. The sixth of the Rochdale Principles states that co-operatives cooperate with each other.
-7. The seventh of the Rochdale Principles states that co-operative societies must have concern for their communities.
-01:24:22	Matt Price: what do we need to cover before we finish up
-01:24:42	dcwalk: maybe resurface open questions, identify if we want to read any of them?
-01:24:56	Matt Price: I think there is something like: there is this tension between individual and collective welfare.
-01:25:26	Matt Price: what does it take to bring them into alignment?
-01:25:45	Matt Price: promise of social media is somehow ALSO rooted the notion of private and collective welfare supporting each other.
-01:25:57	Matt Price:  thx dcwalk ye.
-01:26:33	dcwalk: yeah something important in that last bit
-01:26:43	dcwalk: helpful examples!
-01:27:39	dcwalk: https://en.wikipedia.org/wiki/Bernard_Mandeville
-01:27:39	mash: what’s it called?
-01:27:49	dcwalk: The Fable of the Bees
-01:27:50	Rob Brackett: Thanks!
-01:28:24	dcwalk: classic case of a bad metaphor extended to have dubious descriptive purchase...?
-01:29:16	dcwalk: There is a similar line/tack around commons and justifications of enclosure.
-01:31:05	dcwalk: EDGI taking this up as an anthem? —> https://en.wikipedia.org/wiki/Solidarity_Forever
-01:34:40	dcwalk: I’ll dig up that Mabey on commons rights!
-01:35:32	Matt Price: two things for me:
-01:35:38	Matt Price: - sanctuary and enclosure
-01:36:09	Seong-Young Her: It seemed like everyone was interested in the limitations of the language of ownership, possession, frontiers, etc.
-01:36:42	Matt Price: - and then... I think the *commons* will help clarify my own questions, which I think are around understnading what collective ownership is.
-01:36:45	Matt Price: what it means
-01:37:12	Seong-Young Her: ^agreed!
-01:37:48	Rob Brackett: 👍
-01:40:57	Matt Price: I'm gonna have to sign off!
-01:41:06	Matt Price: aaaahhhhhhh...............
-01:41:29	Matt Price: falling off the channel edge.....................................................................................................................................................................................................................................................................................................................................................................................
-01:41:51	mash: bye-bye! this was really cool!
-01:41:57	Seong-Young Her: thanks Matt!
-01:42:02	Matt Price: next time I'll just try to be on time!
+00:13:20	dcwalk: Just doing intros matt!  
+00:13:37	dcwalk: Asked folks to also add thoughts to the pad  
+00:13:54	Matt Price: I can't hear yet.  sorry, hopefully fix it soon.  
+00:14:15	dcwalk: okay! do your intro last  
+00:14:53	Matt Price: just got it  
+00:15:29	jcahill: problems  
+00:15:31	jcahill: sorry  
+00:15:35	Brendan O'Brien: no worries!  
+00:15:59	Matt Price: mash not matt...  
+00:16:09	dcwalk: Song-Young you next?  
+00:16:13	dcwalk: Then me than matt!  
+00:16:14	Brendan O'Brien: welcome mash!  
+00:16:21	Matt Price: +1  
+00:16:29	dcwalk: Awesome!  
+00:16:49	Brendan O'Brien: lovely! welcome Seong-Young!  
+00:17:16	dcwalk: JCA if you are able to intro please feel free after matt  
+00:17:26	dcwalk: Otherwise I’m handing off facilitator duties  
+00:17:49	dcwalk: My fault!  
+00:18:32	dcwalk: https://hackmd.io/oEcuKALCTi-PbawLmT_Ixw?view  
+00:20:10	mash: me  
+00:23:04	mash: https://onlinelibrary.wiley.com/doi/full/10.1002/bult.2006.1720330108 one of the references from the wiki article that I thought was interesting, relates to the goodreads article as well  
+00:25:33	jccahill: i switched over machines, and apparently accounts (still jeremy here)  
+00:25:54	Rob Brackett: counter-anti, not enough negatives :P  
+00:26:04	Brendan O'Brien: counter-anti-dis  
+00:26:12	Brendan O'Brien: counter-anti-that  
+00:26:12	jccahill: anti-disestablishment-anti-counter-disintermediationism  
+00:27:42	Matt Price: plugged i nthis time.  
+00:27:56	dcwalk: I poorly stepped in!  
+00:28:02	dcwalk: We’re on the wiki article  
+00:28:15	dcwalk: (into the rest :)))  
+00:30:30	dcwalk: Matt P. you on stack?  
+00:30:32	Brendan O'Brien: back when we called it ARPANET?  
+00:30:45	Rob Brackett: virtually raising my hand  
+00:31:06	Matt Price: yes I'm on stack too.  
+00:32:02	Rob Brackett: COLLEGE STUDENT ME NEVER KNEW I COULD HAVE DONE THAT ON FACEBOOK  
+00:32:21	Matt Price: me neever  
+00:32:45	dcwalk: Stack:  
+00:32:46	Brendan O'Brien: and our URL is more popular  
+00:32:53	dcwalk: matt p, rob, then me!  
+00:33:14	Brendan O'Brien: so sorry team I have to jet. jachill & mash that was lovely!  
+00:33:24	dcwalk: by b5!  
+00:33:38	mash: byebye!  
+00:33:40	dcwalk: :( today is typo day  
+00:34:46	jccahill: i don't know enough to speak to the details, but patchwork has been going through some tribulations in its community norms wrt early adopters vs. others  
+00:37:35	mash: stack me  
+00:39:08	Matt Price: interesting @jccahill  
+00:39:12	Matt Price: gotcha mash  
+00:41:03	Matt Price: age of mechanical reproduction (benjamin)  
+00:41:43	Michelle Brous: Hey team, really sorry but some time sensitive things have landed on my desk over the past 20 mins or so. Going to log off - enjoy the convo!  
+00:41:43	Matt Price: the word "capitalism" always so difficult for me b/c it is so broad.  
+00:41:57	Seong-Young Her: me next please  
+00:42:10	Matt Price: gotta bring in the dog, back to you for 3 mins dcwalk  
+00:43:50	dcwalk: phew! you said it so smooth-like :))  
+00:45:32	Matt Price: @mash, so I htink you are talking more broadly about the problem of collective action, is that right?  and how people get the notion that they have strong common interests with their peers.  
+00:46:04	dcwalk: I like that enclosure // sanctuary pairing. yeah  
+00:46:25	jccahill: difference between an enclosure and a sanctuary: whether you want more to be next to the people inside or outside?  
+00:46:48	Matt Price: mechanical turks  
+00:48:50	jccahill: i'd also like to try to address: the flattening of "audience" and content creators on media platforms, in terms of conflating their interests -- which aren't fully aligned. masha and i went through some platformcoop-endorsed/listed alternatives to sites like spotify  
+00:49:00	jccahill: ex. resonate  
+00:49:09	Matt Price: that last point from rob strongly reminded me of michelle's trip to winniped this weekend.  
+00:49:30	Matt Price: she visited the land her metis ancestors had before the metis rebellion in late c. 19.  
+00:50:30	jccahill: dcwalk: that relates to a thing seong and i read recently, about the units of analysis for measuring connectivity in different fields  
+00:50:56	jccahill: is the "more fundamental" unit of social network analysis an actor, or an interaction?  
+00:51:34	mash: put jeremy on the stack pls  
+00:53:10	jccahill: interesting (to me) sociolinguistic note: programmers are perfectly content to use "first-class citizen" in contrast to other things when discussing technical specs, but you don't see this elsewhere ex: computers that actually handle distribution of IPsbehind NAT, etc  
+00:53:16	dcwalk: I AGREE  
+00:53:22	dcwalk: the quote: “The basic strategy of antidisintermediation was formulated by economists like Carl Shapiro and Hal R. Varian. Their influential book Information Rules encourages platform owners to pursue “lock-in.” As they summarize on their website, “Since information technology products work in systems, switching any single product can cost users dearly. The lock-in that results from such switching costs confers a huge competitive advantage to firms that manage their installed base of customers effectively.”  
+00:53:37	dcwalk: “Decentralized systems need to be designed to be counteranti-disintermediationist. Central to the counterantidisintermediationist design is the end- to-end principle; platforms must not depend on servers and admins, even when cooperatively run, but must, to the greatest degree possible, run on the computers of the platforms users.”  
+00:56:36	dcwalk: That seems like a powerful site for action…? people getting called to action  
+00:59:22	mash: reminds me of the history of fandoms (copyright war waged by authors on fan fiction writers/artists)  
+01:00:48	Kevin Nguyen: Can you link to patchwork?  
+01:01:13	dcwalk: https://github.com/ssbc/patchwork y’all should add me on it ;)  
+01:01:43	Kevin Nguyen: thanks!  
+01:05:45	dcwalk: can I go next? (it’ll be short!)  
+01:06:44	Matt Price: after dcwalk I see Rob  
+01:07:39	Matt Price: I would like to make sure we pick up Rob's very first point -- about the divergent interests of owners and users of platforms -- although I think I kind of stopped him from discussing it in more detail earlier :-/  
+01:08:04	Matt Price: oh yeah that too.  
+01:08:51	dcwalk: yeah! +1 Rob’s point  
+01:08:59	dcwalk: dooo it  
+01:09:09	dcwalk: Anna Tsing  
+01:10:25	Matt Price: https://press.princeton.edu/titles/10581.html  
+01:13:02	dcwalk: Other language: nested hierarchy, poly centric (Ostrom) and con federalism (Bookchin!!!!!!!!)  
+01:13:18	Kevin Nguyen: Have to jet early, so good hearing about everything. Thanks all!  
+01:14:47	jccahill: do you want to talk about specific platform coop examples?  
+01:15:23	jccahill: there's an index on the platform.coop site, i'll fetch it  
+01:16:20	Matt Price: also the other site, besides life insurance, of the emergence of actuarial thinking mid-century.  
+01:16:23	Matt Price: 19th  
+01:16:37	jccahill: platform.coop/directory  
+01:16:59	Matt Price: never heard it said out loud before...  
+01:18:15	Matt Price: I feel so ignorant here.  
+01:19:05	Seong-Young Her: the four approaches mentioned by Trebor Scholz:  
+1. Standards and guidelines for platforms to be enforced by policy (e.g. Domestic Workers Alliance's "Good Work Code")  
+2. Economic regulations and union rights (e.g. Seattle tax on Uber)  
+3. Developing non-commercial alternatives (e.g. Wikipedia)  
+4. Platform cooperativism  
+01:19:28	dcwalk: Thanks Seong-Young!  
+01:20:15	Seong-Young Her: the seven Rochdale Principles mentioned by Nathan Schneider (pulled from Wikipedia):  
+1. The first of the Rochdale Principles states that co-operative societies must have an open and voluntary membership.  
+2. The second of the Rochdale Principles states that co-operative societies must have democratic member control.  
+3. Member economic participation is one of the defining features of co-operative societies, and constitutes the third Rochdale Principle in the ICA's Statement on the Co-operative Identity.  
+4. The fourth of the Rochdale Principles states that co-operative societies must be autonomous and independent.  
+5. The fifth of the Rochdale Principles states that co-operative societies must provide education and training to their members and the public.  
+6. The sixth of the Rochdale Principles states that co-operatives cooperate with each other.  
+7. The seventh of the Rochdale Principles states that co-operative societies must have concern for their communities.  
+01:24:22	Matt Price: what do we need to cover before we finish up  
+01:24:42	dcwalk: maybe resurface open questions, identify if we want to read any of them?  
+01:24:56	Matt Price: I think there is something like: there is this tension between individual and collective welfare.  
+01:25:26	Matt Price: what does it take to bring them into alignment?  
+01:25:45	Matt Price: promise of social media is somehow ALSO rooted the notion of private and collective welfare supporting each other.  
+01:25:57	Matt Price:  thx dcwalk ye.  
+01:26:33	dcwalk: yeah something important in that last bit  
+01:26:43	dcwalk: helpful examples!  
+01:27:39	dcwalk: https://en.wikipedia.org/wiki/Bernard_Mandeville  
+01:27:39	mash: what’s it called?  
+01:27:49	dcwalk: The Fable of the Bees  
+01:27:50	Rob Brackett: Thanks!  
+01:28:24	dcwalk: classic case of a bad metaphor extended to have dubious descriptive purchase...?  
+01:29:16	dcwalk: There is a similar line/tack around commons and justifications of enclosure.  
+01:31:05	dcwalk: EDGI taking this up as an anthem? —> https://en.wikipedia.org/wiki/Solidarity_Forever  
+01:34:40	dcwalk: I’ll dig up that Mabey on commons rights!  
+01:35:32	Matt Price: two things for me:  
+01:35:38	Matt Price: - sanctuary and enclosure  
+01:36:09	Seong-Young Her: It seemed like everyone was interested in the limitations of the language of ownership, possession, frontiers, etc.  
+01:36:42	Matt Price: - and then... I think the *commons* will help clarify my own questions, which I think are around understnading what collective ownership is.  
+01:36:45	Matt Price: what it means  
+01:37:12	Seong-Young Her: ^agreed!  
+01:37:48	Rob Brackett: 👍  
+01:40:57	Matt Price: I'm gonna have to sign off!  
+01:41:06	Matt Price: aaaahhhhhhh...............  
+01:41:29	Matt Price: falling off the channel edge.....................................................................................................................................................................................................................................................................................................................................................................................  
+01:41:51	mash: bye-bye! this was really cool!  
+01:41:57	Seong-Young Her: thanks Matt!  
+01:42:02	Matt Price: next time I'll just try to be on time!  

--- a/notes/2-ownership-2018-07-24.md
+++ b/notes/2-ownership-2018-07-24.md
@@ -9,15 +9,15 @@ where owners wanted to e
 
 **Readings**
 
-- Selections from [_Ours to Hack and to Own_](http://www.orbooks.com/catalog/ours-to-hack-and-to-own/) (2016) edited by Trebor Scholz and Nathan Schneider
+- Selections from [_Ours to Hack and to Own_](http://www.orbooks.com/catalog/ours-to-hack-and-to-own/) (2016) edited by Trebor Scholz and Nathan Schneider ([WorldCat](https://www.worldcat.org/title/ours-to-hack-and-to-own-the-rise-of-platform-cooperativism-a-new-vision-for-the-future-of-work-and-a-fairer-internet/oclc/1044840227))
   - Chapter 3: Trebor Scholz - How Platform Cooperativism Can Unleash the Network
   - Chapter 2: Nathan Schneider - The Meanings of Words
   - Chapter 12: Dmytri Kleiner - Counterantidisintermediation
     - _See also_: P2P Foundation wiki entry on [Counter-Anti-Disintermediation](http://wiki.p2pfoundation.net/Counter-Anti-Disintermediation)
 - Anne-Mette Albrechtslund (2017) [Negotiating ownership and agency in social media: Community reactions to Amazon's acquisition of GoodReads. _First Monday_, may 2017. doi:10.5210/fm.v22i5.7095 ](http://firstmonday.org/ojs/index.php/fm/article/view/7095/6161)
-- **[Possession is Nine Tenths of the Law](https://en.wikipedia.org/wiki/Possession_is_nine-tenths_of_the_law)**
-  - (Bonus) [Trademarks, copyrights and common law: possession is only nine-tenths of the law](http://kelleykeller.com/the-limitations-of-common-law-possession-is-only-nine-tenths-of-the-law/)
-  - (Bonus x2) [The Problematic Concept of Possession in the DCFR: Lessons from Law and Economics of Possession](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2741200)
+- **[Possession is Nine Tenths of the Law](https://en.wikipedia.org/wiki/Possession_is_nine-tenths_of_the_law)**. (2018, July 15). In _Wikipedia, The Free Encyclopedia_.
+    - _See also_: [Trademarks, copyrights and common law: possession is only nine-tenths of the law](http://kelleykeller.com/the-limitations-of-common-law-possession-is-only-nine-tenths-of-the-law/)
+    - _See also x2_: [The Problematic Concept of Possession in the DCFR: Lessons from Law and Economics of Possession](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2741200)
 
 ### Themes
 


### PR DESCRIPTION
edit: 

Did some minor cleaning up of the readme as well as the chat logs of the notes for session 1 and 2 in order to make them more readable and consistent. I.e., aligned bibliographic formatting, readings consistent across notes, typos corrected, whitespaces added for line breaks.

There are other things to do to these docs as in #20... add in links to recorded calls and notes from readme, recorded call link in notes, etc. however I'll leave that to another time/PR!