### PR TITLE
Add links to call recordings and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ From this initial iteration, our hope is that: first, we learn together!; second
 
 ## Themes  
 
-- [A view on the decentralized (distributed) web](#a-view-on-the-decentralized-distributed-web) (June 26)
-- [Ownership](#ownership) (July 24)
-- [Commons](#commons) (August 21)
+- [A view on the decentralized (distributed) web](#a-view-on-the-decentralized-distributed-web) (June 26)   
+[🎬 **Recorded Call**](https://youtu.be/arkTPNnSBbk) &nbsp; [🗒 **Notes**](./1-decentralized-web-2018-06-26.md)
+- [Ownership](#ownership) (July 24)   
+[🎬 **Recorded Call**](https://youtu.be/b9tOkZCFhB4) &nbsp; [🗒 **Notes**](./2-ownership-2018-07-24.md)
+- [Commons](#commons) (August 21)   
+[🎬 **Recorded Call**](https://youtu.be/UqDYpMhqV6M) &nbsp; [🗒 **Notes**](./3-commons-2018-08-21.md)
 - [Centralization as opposed to Decentralization (and peer-to-peer, federation)](#centralization-vs-decentralization-and-peer-to-peer-federation) (September 4)
 - [Privacy](#privacy) (September 25)
 - [Justice](#justice) (October 30)
@@ -114,7 +117,7 @@ Extra Reading:
 
 Here are some guidelines about preparation in order to facilitate a session:
 
-- Before the session: 
+- Before the session:
   - Have read and thought about the texts
   - Identify and write 2-4 "themes" or questions you are interested in from the readings
   - We use the same [shared notepad](https://hackmd.io/oEcuKALCTi-PbawLmT_Ixw#): https://hackmd.io/oEcuKALCTi-PbawLmT_Ixw#, which has a template for notes
@@ -122,7 +125,7 @@ Here are some guidelines about preparation in order to facilitate a session:
   - Arrive on time (call should auto record as the first person enters)
   - Ensure the call is recorded (it should auto-record as the first person enters, but always make sure someone presses the record button if not)
   - Ask for someone to take notes
-  - Keep time and gently wrap us up 
+  - Keep time and gently wrap us up
 - After the session:
   - Copy the notes and open a pull request in [this repository](https://github.com/datatogether/reading_datatogether/tree/master/notes)
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ From this initial iteration, our hope is that: first, we learn together!; second
 ## Themes  
 
 - [A view on the decentralized (distributed) web](#a-view-on-the-decentralized-distributed-web) (June 26)   
-[🎬 **Recorded Call**](https://youtu.be/arkTPNnSBbk) &nbsp; [🗒 **Notes**](./1-decentralized-web-2018-06-26.md)
+[🎬 **Recorded Call**](https://youtu.be/arkTPNnSBbk) &nbsp; [🗒 **Notes**](./notes/1-decentralized-web-2018-06-26.md)
 - [Ownership](#ownership) (July 24)   
-[🎬 **Recorded Call**](https://youtu.be/b9tOkZCFhB4) &nbsp; [🗒 **Notes**](./2-ownership-2018-07-24.md)
+[🎬 **Recorded Call**](https://youtu.be/b9tOkZCFhB4) &nbsp; [🗒 **Notes**](./notes/2-ownership-2018-07-24.md)
 - [Commons](#commons) (August 21)   
-[🎬 **Recorded Call**](https://youtu.be/UqDYpMhqV6M) &nbsp; [🗒 **Notes**](./3-commons-2018-08-21.md)
+[🎬 **Recorded Call**](https://youtu.be/UqDYpMhqV6M) &nbsp; [🗒 **Notes**](./notes/3-commons-2018-08-21.md)
 - [Centralization as opposed to Decentralization (and peer-to-peer, federation)](#centralization-vs-decentralization-and-peer-to-peer-federation) (September 4)
 - [Privacy](#privacy) (September 25)
 - [Justice](#justice) (October 30)

--- a/notes/1-decentralized-web-2018-06-26.md
+++ b/notes/1-decentralized-web-2018-06-26.md
@@ -1,6 +1,8 @@
 # Data. Together. Let's read about it
 
-## 1: A view on the decentralized (distributed) web (June 26)
+## A view on the decentralized (distributed) web (June 26)
+
+[🎬 **Recorded Call**](https://youtu.be/arkTPNnSBbk)
 
 ### Intro
 

--- a/notes/2-ownership-2018-07-24.md
+++ b/notes/2-ownership-2018-07-24.md
@@ -2,6 +2,8 @@
 
 ## Ownership (July 24)
 
+[🎬 **Recorded Call**](https://youtu.be/b9tOkZCFhB4)
+
 ### Intro
 
 Sometimes when we talk about Data Together we use phrases like "communities taking ownership of their data". What do we mean, and why is this language important to us?
@@ -31,7 +33,7 @@ where owners wanted to e
     > What does all this require in terms of individuals using the tech understanding how it works? How do we make that work/support that?
 - In "How Platform Cooperativism...", Scholz places a lot of emphasis on the  virtue of equality. How do we weigh that virtue against others (eg freedom), and in what contexts?
 
-### Meeting Notes
+### Notes
 
 - dcwalk: what are the implications of using language of ownership?
 - b5: every topic seemed to need some paired concept (e.g. use of capitalism in the )

--- a/notes/3-commons-2018-08-21.md
+++ b/notes/3-commons-2018-08-21.md
@@ -2,6 +2,8 @@
 
 ## Commons (August 21)
 
+[🎬 **Recorded Call**](https://youtu.be/UqDYpMhqV6M)
+
 ### Intro
 
 Sometimes, instead of ownership, we talk about a "commons". How ought the commons to be governed, and by whom?
@@ -36,8 +38,6 @@ Sometimes, instead of ownership, we talk about a "commons". How ought the common
 - De Filippi: "The success of Wi-Fi has proven Coase's defense of a market-based approach as the sole alternative to exclusive licensing to be overly simplistic. Against the backdrop of traditional economic theory, open spectrum policies has shown that commons-based approach to many-to-many communication infrastructure can actually work in practice. Through packet switching, best-effort delivery, as well as innovative radio transmission and banDCidth managements techniques, Wi-Fi has successfully verified Ostrom's claim that users themselves can create and enforce rules that mitigate the over-exploitation of the commons, confirming the point that orthodox economists usually overlook the practical failures of privatization and government regulation (Ostrom, 1990). In many regards, though property-based allocations of spectrum and exclusive licensing still have the upper half, it has often come short of fostering public interest goals, by creating a very significant underutilization of public resource.54 Moreover, not only does the regulatory focus on exclusive licensing create an enormous opportunity cost by favoring established players over innovative new-entrants (such as community networks), it has even been argued by human rights NGOs that it may actually breach the international law on freedom of expression (Article 19, 2005)."
 
 ### Notes
-
-[🎬 Recorded Call](https://www.youtube.com/watch?v=UqDYpMhqV6M&index=27&list=PLtsP3g9LafVul1gCctMYGm9sz5FUWr5bu)  
 
 - Review of Elinor Ostrom Governing the Commons: against the tragedy of the commons, took seriously game theory and prisoners dilemma as well as view that private/public were the only public examples
   - MZ: Make sure we talk about: is data or knowledge a common? the readings focus on natural resources


### PR DESCRIPTION
This was discussed/introduced in https://github.com/datatogether/reading_datatogether/pull/20, particularly https://github.com/datatogether/reading_datatogether/pull/20/commits/6ee27d3061990dea0e48d1270d9ce2ef67639c07 so carrying this throughout the readme and previous call notes here