### PR TITLE
Clarify the Ostrom/Hess reading is only Chapter 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Let’s revisit last semester’s ideaas around governing the commons, but with 
 
 **Readings:**
 
-1. Ostrom and Hess [“A Framework for Analyzing the Knowledge Commons”](http://www.wtf.tw/ref/hess_ostrom_2007.pdf)
+1. Ostrom and Hess “A Framework for Analyzing the Knowledge Commons” (Chapter 3, pages 41-81 of *Understanding Knowledge as a Commons*) (http://www.wtf.tw/ref/hess_ostrom_2007.pdf)
 2. Melanie Dulong de Rosnay, Hervé Le Crosnier. [An Introduction to the Digital Commons: From Common-Pool Resources to Community Governance.](https://halshs.archives-ouvertes.fr/halshs-00736920/document), 2012.
 3. This twitter thread from mmildenberger: https://twitter.com/mmildenberger/status/1102604887223750657
 4. Garrett Hardin’s [“The Tragedy of the Commons”](http://science.sciencemag.org/content/162/3859/1243/tab-pdf)


### PR DESCRIPTION
This got mixed up and confused because we linked a PDF of the whole book, but the title was of just chapter 3, and is the only part that we intended for reading here. (Doubly confusing because the name of the chapter and the name of the book are very close.)

Is this right, @ericnost/@b5?